### PR TITLE
Add code climate badges and configure reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The NGP VAN Ruby Gem
 
-[![Circle CI](https://circleci.com/gh/christopherstyles/ngp_van.svg?style=svg&circle-token=410c1ce6c4fd70b078726dffb0497bda82cbb983)](https://circleci.com/gh/christopherstyles/ngp_van)
+[![Circle CI](https://circleci.com/gh/christopherstyles/ngp_van.svg?style=svg&circle-token=410c1ce6c4fd70b078726dffb0497bda82cbb983)](https://circleci.com/gh/christopherstyles/ngp_van) [![Test Coverage](https://codeclimate.com/github/christopherstyles/ngp_van/badges/coverage.svg)](https://codeclimate.com/github/christopherstyles/ngp_van/coverage) [![Code Climate](https://codeclimate.com/github/christopherstyles/ngp_van/badges/gpa.svg)](https://codeclimate.com/github/christopherstyles/ngp_van)
 
 An unofficial Ruby wrapper for the [NGP VAN](http://developers.everyaction.com/) RESTful API.
 

--- a/ngp_van.gemspec
+++ b/ngp_van.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '~> 0.9.2'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.10.0'
 
+  spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'faker', '~> 1.6'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'codeclimate-test-reporter'
+CodeClimate::TestReporter.start
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'ngp_van'
 require 'faker'
-require 'webmock/rspec'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow: 'codeclimate.com')


### PR DESCRIPTION
This update adds new badges for code climate test coverage and GPA.

* Add code climate to development dependencies.
* Add code climate badges to README.
* Start the code climate test reporter at head of `spec_helper`.
* Configure `webmock` to allow `codeclimate.com`.
* Move webmock require to support file.