### PR TITLE
Add a badge for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The NGP VAN Ruby Gem
 
-[![Circle CI](https://circleci.com/gh/christopherstyles/ngp_van.svg?style=svg&circle-token=410c1ce6c4fd70b078726dffb0497bda82cbb983)](https://circleci.com/gh/christopherstyles/ngp_van) [![Test Coverage](https://codeclimate.com/github/christopherstyles/ngp_van/badges/coverage.svg)](https://codeclimate.com/github/christopherstyles/ngp_van/coverage) [![Code Climate](https://codeclimate.com/github/christopherstyles/ngp_van/badges/gpa.svg)](https://codeclimate.com/github/christopherstyles/ngp_van)
+[![Circle CI](https://circleci.com/gh/christopherstyles/ngp_van.svg?style=svg&circle-token=410c1ce6c4fd70b078726dffb0497bda82cbb983)](https://circleci.com/gh/christopherstyles/ngp_van) [![Test Coverage](https://codeclimate.com/github/christopherstyles/ngp_van/badges/coverage.svg)](https://codeclimate.com/github/christopherstyles/ngp_van/coverage) [![Code Climate](https://codeclimate.com/github/christopherstyles/ngp_van/badges/gpa.svg)](https://codeclimate.com/github/christopherstyles/ngp_van) [![Inline docs](http://inch-ci.org/github/christopherstyles/ngp_van.svg?branch=master)](http://inch-ci.org/github/christopherstyles/ngp_van)
 
 An unofficial Ruby wrapper for the [NGP VAN](http://developers.everyaction.com/) RESTful API.
 


### PR DESCRIPTION
[Inch CI](https://inch-ci.org) is a hosted continuous integration service that evaluates inline code documentation. 

This update adds a badge showing a report grade for each class, module, method, function etc.