### PR TITLE
Add a version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The NGP VAN Ruby Gem
 
-[![Circle CI](https://circleci.com/gh/christopherstyles/ngp_van.svg?style=svg&circle-token=410c1ce6c4fd70b078726dffb0497bda82cbb983)](https://circleci.com/gh/christopherstyles/ngp_van) [![Test Coverage](https://codeclimate.com/github/christopherstyles/ngp_van/badges/coverage.svg)](https://codeclimate.com/github/christopherstyles/ngp_van/coverage) [![Code Climate](https://codeclimate.com/github/christopherstyles/ngp_van/badges/gpa.svg)](https://codeclimate.com/github/christopherstyles/ngp_van) [![Inline docs](http://inch-ci.org/github/christopherstyles/ngp_van.svg?branch=master)](http://inch-ci.org/github/christopherstyles/ngp_van)
+[![Circle CI](https://circleci.com/gh/christopherstyles/ngp_van.svg?style=svg&circle-token=410c1ce6c4fd70b078726dffb0497bda82cbb983)](https://circleci.com/gh/christopherstyles/ngp_van) [![Test Coverage](https://codeclimate.com/github/christopherstyles/ngp_van/badges/coverage.svg)](https://codeclimate.com/github/christopherstyles/ngp_van/coverage) [![Code Climate](https://codeclimate.com/github/christopherstyles/ngp_van/badges/gpa.svg)](https://codeclimate.com/github/christopherstyles/ngp_van) [![Inline docs](http://inch-ci.org/github/christopherstyles/ngp_van.svg?branch=master)](http://inch-ci.org/github/christopherstyles/ngp_van) [![Gem Version](https://badge.fury.io/rb/ngp_van.svg)](https://badge.fury.io/rb/ngp_van)
 
 An unofficial Ruby wrapper for the [NGP VAN](http://developers.everyaction.com/) RESTful API.
 


### PR DESCRIPTION
This update adds a version badge, so it’s easier to see at a glance what version the gem currently is at.

[![Gem Version](https://badge.fury.io/rb/ngp_van.svg)](https://badge.fury.io/rb/ngp_van)