### PR TITLE
Add ability to vary configuration per client object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ doc
 pkg
 spec/reports
 tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Options can also be set on the configuration object:
 # => "de286a1a-f2e7-421a-91b8-f8cc8201558f|1"
 ```
 
+In a multi-threaded environment you may want to use multiple configurations simultaneously. 
+In that case, pass an appropriately setup configuration class to the client object.
+
+```ruby
+configuration = NgpVan::Configuration.new
+configuration.api_key = 'de286a1a-f2e7-421a-91b8-f8cc8201558f|1'
+client = NgpVan::Client.new(configuration)
+client.district_fields
+
+```
+
 ## Making requests
 
 API Methods can be called as module methods or as instance methods on the client.

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -7,6 +7,7 @@ require 'ngp_van/client/activist_codes'
 require 'ngp_van/client/canvass_responses'
 require 'ngp_van/client/codes'
 require 'ngp_van/client/district_fields'
+require 'ngp_van/client/echoes'
 require 'ngp_van/client/events'
 require 'ngp_van/client/event_types'
 require 'ngp_van/client/locations'
@@ -36,6 +37,7 @@ module NgpVan
     include NgpVan::Client::CanvassResponses
     include NgpVan::Client::Codes
     include NgpVan::Client::DistrictFields
+    include NgpVan::Client::Echoes
     include NgpVan::Client::Events
     include NgpVan::Client::EventTypes
     include NgpVan::Client::Locations

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -20,6 +20,15 @@ require 'ngp_van/client/users'
 
 module NgpVan
   class Client
+
+    def initialize(configuration = nil)
+      @config = configuration
+    end
+
+    def config
+      @config || NgpVan.configuration
+    end
+
     include NgpVan::Connection
     include NgpVan::Request
     include NgpVan::Response

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -17,6 +17,7 @@ require 'ngp_van/client/printed_lists'
 require 'ngp_van/client/minivan_exports'
 require 'ngp_van/client/signups'
 require 'ngp_van/client/survey_questions'
+require 'ngp_van/client/supporter_groups'
 require 'ngp_van/client/users'
 
 module NgpVan
@@ -46,6 +47,7 @@ module NgpVan
     include NgpVan::Client::PrintedLists
     include NgpVan::Client::MinivanExports
     include NgpVan::Client::Signups
+    include NgpVan::Client::SupporterGroups
     include NgpVan::Client::SurveyQuestions
     include NgpVan::Client::Users
   end

--- a/lib/ngp_van/client/echoes.rb
+++ b/lib/ngp_van/client/echoes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module Echoes
+      def echoes(message:)
+        post(path: 'echoes', body: {message: message})
+      end
+    end
+  end
+end

--- a/lib/ngp_van/client/people.rb
+++ b/lib/ngp_van/client/people.rb
@@ -26,6 +26,10 @@ module NgpVan
       def create_canvass_responses_for_person_by_type(id:, type:, body: {})
         post(path: "people/#{type}:#{id}/canvassResponses", body: body)
       end
+
+      def apply_code_to_person(id:, body: {})
+        post(path: "people/#{id}/codes", body: body)
+      end
     end
   end
 end

--- a/lib/ngp_van/client/supporter_groups.rb
+++ b/lib/ngp_van/client/supporter_groups.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module SupporterGroups
+      def create_supporter_group(body: {})
+        post(path: 'supporterGroups', body: body)
+      end
+
+      def supporter_group(id:, params: {})
+        get(path: "supporterGroups/#{id}", params: params)
+      end
+
+      def supporter_groups(params: {})
+        get(path: 'supporterGroups', params: params)
+      end
+
+      def add_person_to_support_group(supporter_group_id:, id:)
+        put(path: "supporterGroups/#{supporter_group_id}/people/#{id}")
+      end
+
+      def remove_person_from_supporter_group(supporter_group_id:, id:)
+        delete(path: "supporterGroups/#{supporter_group_id}/people/#{id}")
+      end
+    end
+  end
+end

--- a/lib/ngp_van/connection.rb
+++ b/lib/ngp_van/connection.rb
@@ -10,17 +10,17 @@ module NgpVan
     # rubocop:disable Metrics/MethodLength
     def connection
       options = {
-        url: NgpVan.configuration.api_endpoint,
+        url: config.api_endpoint,
         headers: {
           'Accept' => 'application/json; charset=utf-8',
-          'User-Agent' => NgpVan.configuration.user_agent
+          'User-Agent' => config.user_agent
         }
       }
 
       Faraday::Connection.new(options) do |connection|
         connection.basic_auth(
-          NgpVan.configuration.application_name,
-          NgpVan.configuration.api_key
+          config.application_name,
+          config.api_key
         )
 
         connection.request(:json)

--- a/lib/ngp_van/error.rb
+++ b/lib/ngp_van/error.rb
@@ -3,7 +3,7 @@
 module NgpVan
   # Custom error class for rescuing from NgpVan errors.
   class Error < StandardError
-    attr_reader :body, :response, :status
+    attr_reader :body, :response, :status, :errors
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize,
     # rubocop:disable Style/CyclomaticComplexity
@@ -45,15 +45,12 @@ module NgpVan
       @response = response
       @body = ::JSON.parse(response[:body])
       @status = response[:status]
+      @errors = body.delete('errors')
 
       super(build_error)
     end
 
     private
-
-    def errors
-      body.delete('errors')
-    end
 
     def build_error
       return nil if response.nil?

--- a/lib/ngp_van/version.rb
+++ b/lib/ngp_van/version.rb
@@ -7,7 +7,7 @@ module NgpVan
 
   # Current minor release.
   # @return [Integer]
-  MINOR = 1
+  MINOR = 2
 
   # Current patch level.
   # @return [Integer]

--- a/ngp_van.gemspec
+++ b/ngp_van.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.summary = 'Ruby wrapper for the NGP VAN API'
   spec.version = NgpVan::VERSION.dup
 
-  spec.add_runtime_dependency 'faraday', '~> 0.9.2'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 0.10.0'
+  spec.add_runtime_dependency 'faraday', '> 0.9.2'
+  spec.add_runtime_dependency 'faraday_middleware', '> 0.10.0'
 
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0'
   spec.add_development_dependency 'faker', '~> 1.6'

--- a/spec/ngp_van/client/supporter_groups_spec.rb
+++ b/spec/ngp_van/client/supporter_groups_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  # rubocop:disable Metrics/ClassLength
+  class Client
+    RSpec.describe SupporterGroups do
+      let(:client) { NgpVan::Client.new }
+
+      describe '#create_supporter_group' do
+        let(:body) do
+          JSON.parse(fixture('create_supporter_group.json').read)
+        end
+
+        let(:url) { build_url(client: client, path: 'supporterGroups') }
+
+        before do
+          stub_request(:post, url)
+            .with(body: JSON.generate(body))
+            .to_return(
+              body: '1122',
+              status: 201,
+              headers: {
+                'Location' => build_url(client: client, path: '/supporterGroups/1122')
+              }
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.create_supporter_group(body: body)
+          expect(
+            a_request(:post, url)
+              .with(
+                body: body
+              )
+          ).to have_been_made
+        end
+
+        it 'returns the created id' do
+          expect(client.create_supporter_group(body: body)).to eq(1122)
+        end
+      end
+
+      describe '#supporter_group' do
+        let(:response) { fixture('supporter_group.json') }
+        let(:url) { build_url(client: client, path: 'supporterGroups/1122') }
+
+        before do
+          stub_request(:get, url).to_return(body: response)
+        end
+
+        it 'requests the correct resource' do
+          client.supporter_group(id: 1122)
+          expect(a_request(:get, url)).to have_been_made
+        end
+
+        it 'returns a event object' do
+          supporter_group = client.supporter_group(id: 1122)
+          expect(supporter_group).to be_a(Hash)
+        end
+
+        it 'returns the requested supporter group' do
+          supporter_group = client.supporter_group(id: 1122)
+          expect(supporter_group['id']).to eq(1122)
+        end
+      end
+
+      describe '#supporter_groups' do
+        let(:params) do
+          {
+            '$top' => 2
+          }
+        end
+
+        let(:response) { fixture('supporter_groups.json') }
+        let(:url) { build_url(client: client, path: 'supporterGroups') }
+
+        before do
+          stub_request(:get, url)
+            .with(query: params)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.supporter_groups(params: params)
+          expect(
+            a_request(:get, url)
+              .with(query: params)
+          ).to have_been_made
+        end
+
+        it 'returns an array of items' do
+          supporter_groups = client.supporter_groups(params: params)
+          expect(supporter_groups['items']).to be_a(Array)
+        end
+
+        it 'returns the requested supporter groups' do
+          supporter_groups = client.supporter_groups(params: params)
+          expect(supporter_groups['items'].first['id']).to eq(1122)
+        end
+      end
+
+      describe '#add_person_to_support_group' do
+        let(:url) { build_url(client: client, path: 'supporterGroups/1122/people/3344') }
+
+        before do
+          stub_request(:put, url).to_return(status: 204)
+        end
+
+        it 'requests the correct resource' do
+          client.add_person_to_support_group(supporter_group_id: 1122, id: 3344)
+          expect(a_request(:put, url)).to have_been_made
+        end
+      end
+
+      describe '#remove_person_from_supporter_group' do
+        let(:url) { build_url(client: client, path: 'supporterGroups/1122/people/3344') }
+
+        before do
+          stub_request(:delete, url).to_return(status: 204)
+
+          it 'requests the correct resource' do
+            client.add_person_to_support_group(supporter_group_id: 1122, id: 3344)
+            expect(a_request(:delete, url)).to have_been_made
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ngp_van/client_spec.rb
+++ b/spec/ngp_van/client_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  RSpec.describe Client do
+    describe 'initialization' do
+      describe 'with a specified configuration' do
+        let(:config) { NgpVan::Configuration.new }
+
+        subject { NgpVan::Client.new(config) }
+
+        it 'should accept and store as config' do
+          expect(subject.config).to eq(config)
+        end
+      end
+
+      describe 'without a specified config' do
+        it 'should get the default' do
+          expect(subject.config).to eq(NgpVan.configuration)
+        end
+      end
+    end
+
+    describe 'usage' do
+      it 'should be possible to build a config and use it per client' do
+        configuration = NgpVan::Configuration.new
+        configuration.user_agent = 'test agent'
+        client = NgpVan::Client.new(configuration)
+        expect(client.config.user_agent).to eq('test agent')
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/create_supporter_group.json
+++ b/spec/support/fixtures/create_supporter_group.json
@@ -1,0 +1,4 @@
+{
+    "name": "North End Volunteers",
+    "description": "Volunteers from the North End that help out frequently"
+}

--- a/spec/support/fixtures/supporter_group.json
+++ b/spec/support/fixtures/supporter_group.json
@@ -1,0 +1,5 @@
+{
+    "id": 1122,
+    "name": "North End Volunteers",
+    "description": "Volunteers from the North End that help out frequently"
+}

--- a/spec/support/fixtures/supporter_groups.json
+++ b/spec/support/fixtures/supporter_groups.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "id": 1122,
+      "name": "North End Volunteers",
+      "description": "Volunteers from the North End that help out frequently"
+    },
+    {
+      "id": 1123,
+      "name": "South End Volunteers",
+      "description": "Volunteers from the South End that help out not so frequently"
+    }
+  ],
+  "nextPageLink": "https://api.securevan.com:443/v4/supporterGroups?$top=2&$skip=2",
+  "count": 5
+}


### PR DESCRIPTION
We would like to use this gem to process API calls in a multi-tenant environment where some threads may be connecting to multiple EveryAction databases for different clients at the same time. 

This change allows the configuration of client object's credentials on a per instance basis. 