### PR TITLE
Update Travis configuration and support Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: ruby
 
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - ruby-head
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem install bundler -v '< 2'
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'bundler', '~> 1.6'
+gem 'bundler', '>= 1.7', '<= 2.0.1'
 gem 'faker', '~> 1.6'
 gem 'pry'
 gem 'rake', '< 11.0'


### PR DESCRIPTION
Since RubyGems 3.0.0 is only installable on Ruby >= 2.3, this update specifies installing a prior version to maintain compatibility.

In addition, the rubies being tested against have been updated to reflect only stable versions.

See: rubygems/rubygems#2534