### PR TITLE
Verify ids to guard against SSRF

### DIFF
--- a/lib/ngp_van.rb
+++ b/lib/ngp_van.rb
@@ -5,11 +5,11 @@ require 'ngp_van/configuration'
 require 'ngp_van/version'
 
 module NgpVan
-  class << self
-    # The NgpVan configuration object.
-    # @return [NgpVan::Configuration]
-    attr_reader :configuration
+  class Invalid < StandardError; end
 
+  class InvalidID < Invalid; end
+
+  class << self
     def client
       @client ||= NgpVan::Client.new
     end

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -23,7 +23,6 @@ require 'ngp_van/client/users'
 
 module NgpVan
   class Client
-
     def initialize(configuration = nil)
       @config = configuration
     end
@@ -31,6 +30,18 @@ module NgpVan
     def config
       @config || NgpVan.configuration
     end
+
+    def valid_id?(id)
+      id.to_s =~ /\A[a-z0-9\-]+\z/i ? true : false
+    end
+
+    def verify_id(*ids)
+      ids.each do |id|
+        raise NgpVan::InvalidID unless valid_id?(id)
+      end
+      nil
+    end
+    alias_method :verify_ids, :verify_id
 
     include NgpVan::Connection
     include NgpVan::Request

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -32,7 +32,7 @@ module NgpVan
     end
 
     def valid_id?(id)
-      id.to_s =~ /\A[a-z0-9\-]+\z/i ? true : false
+      id.to_s =~ /\A[a-z0-9\-:]+\z/i ? true : false
     end
 
     def verify_id(*ids)

--- a/lib/ngp_van/client/activist_codes.rb
+++ b/lib/ngp_van/client/activist_codes.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def activist_code(id:, params: {})
+        verify_id(id)
         get(path: "activistCodes/#{id}", params: params)
       end
     end

--- a/lib/ngp_van/client/codes.rb
+++ b/lib/ngp_van/client/codes.rb
@@ -12,6 +12,7 @@ module NgpVan
       end
 
       def code(id:, params: {})
+        verify_id(id)
         get(path: "codes/#{id}", params: params)
       end
 
@@ -20,10 +21,12 @@ module NgpVan
       end
 
       def update_code(id:, body: {})
+        verify_id(id)
         put(path: "codes/#{id}", body: body)
       end
 
       def delete_code(id:)
+        verify_id(id)
         delete(path: "codes/#{id}")
       end
     end

--- a/lib/ngp_van/client/district_fields.rb
+++ b/lib/ngp_van/client/district_fields.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def district_field(id:)
+        verify_id(id)
         get(path: "districtFields/#{id}")
       end
     end

--- a/lib/ngp_van/client/event_types.rb
+++ b/lib/ngp_van/client/event_types.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def event_type(id:, params: {})
+        verify_id(id)
         get(path: "events/types/#{id}", params: params)
       end
     end

--- a/lib/ngp_van/client/events.rb
+++ b/lib/ngp_van/client/events.rb
@@ -8,10 +8,12 @@ module NgpVan
       end
 
       def create_event_shift(id:, body: {})
+        verify_id(id)
         post(path: "events/#{id}/shifts", body: body)
       end
 
       def event(id:, params: {})
+        verify_id(id)
         get(path: "events/#{id}", params: params)
       end
 
@@ -20,10 +22,12 @@ module NgpVan
       end
 
       def update_event(id:, body: {})
+        verify_id(id)
         put(path: "events/#{id}", body: body)
       end
 
       def delete_event(id:)
+        verify_id(id)
         delete(path: "events/#{id}")
       end
     end

--- a/lib/ngp_van/client/locations.rb
+++ b/lib/ngp_van/client/locations.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def location(id:, params: {})
+        verify_id(id)
         get(path: "locations/#{id}", params: params)
       end
 
@@ -20,6 +21,7 @@ module NgpVan
       end
 
       def delete_location(id:)
+        verify_id(id)
         delete(path: "locations/#{id}")
       end
     end

--- a/lib/ngp_van/client/minivan_exports.rb
+++ b/lib/ngp_van/client/minivan_exports.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def minivan_export(id:, params: {})
+        verify_id(id)
         get(path: "minivanExports/#{id}", params: params)
       end
     end

--- a/lib/ngp_van/client/notes.rb
+++ b/lib/ngp_van/client/notes.rb
@@ -12,6 +12,7 @@ module NgpVan
       end
 
       def note_category(id:, params: {})
+        verify_id(id)
         get(path: "notes/categories/#{id}", params: params)
       end
     end

--- a/lib/ngp_van/client/people.rb
+++ b/lib/ngp_van/client/people.rb
@@ -12,18 +12,22 @@ module NgpVan
       end
 
       def person(id:, params: {})
+        verify_id(id)
         get(path: "people/#{id}", params: params)
       end
 
       def person_by_type(id:, type:, params: {})
+        verify_ids(id, type)
         get(path: "people/#{type}:#{id}", params: params)
       end
 
       def create_canvass_responses_for_person(id:, body: {})
+        verify_id(id)
         post(path: "people/#{id}/canvassResponses", body: body)
       end
 
       def create_canvass_responses_for_person_by_type(id:, type:, body: {})
+        verify_ids(id, type)
         post(path: "people/#{type}:#{id}/canvassResponses", body: body)
       end
     end

--- a/lib/ngp_van/client/printed_lists.rb
+++ b/lib/ngp_van/client/printed_lists.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def printed_list(id:, params: {})
+        verify_id(id)
         get(path: "printedLists/#{id}", params: params)
       end
     end

--- a/lib/ngp_van/client/signups.rb
+++ b/lib/ngp_van/client/signups.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def signup(id:, params: {})
+        verify_id(id)
         get(path: "signups/#{id}", params: params)
       end
 
@@ -20,10 +21,12 @@ module NgpVan
       end
 
       def update_signup(id:, body: {})
+        verify_id(id)
         put(path: "signups/#{id}", body: body)
       end
 
       def delete_signup(id:)
+        verify_id(id)
         delete(path: "signups/#{id}")
       end
     end

--- a/lib/ngp_van/client/supporter_groups.rb
+++ b/lib/ngp_van/client/supporter_groups.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def supporter_group(id:, params: {})
+        verify_id(id)
         get(path: "supporterGroups/#{id}", params: params)
       end
 
@@ -16,10 +17,12 @@ module NgpVan
       end
 
       def add_person_to_supporter_group(supporter_group_id:, id:)
+        verify_ids(id, supporter_group_id)
         put(path: "supporterGroups/#{supporter_group_id}/people/#{id}")
       end
 
       def remove_person_from_supporter_group(supporter_group_id:, id:)
+        verify_ids(id, supporter_group_id)
         delete(path: "supporterGroups/#{supporter_group_id}/people/#{id}")
       end
     end

--- a/lib/ngp_van/client/survey_questions.rb
+++ b/lib/ngp_van/client/survey_questions.rb
@@ -8,6 +8,7 @@ module NgpVan
       end
 
       def survey_question(id:, params: {})
+        verify_id(id)
         get(path: "surveyQuestions/#{id}", params: params)
       end
     end

--- a/lib/ngp_van/client/users.rb
+++ b/lib/ngp_van/client/users.rb
@@ -4,14 +4,17 @@ module NgpVan
   class Client
     module Users
       def user_district_field_values(id:, params: {})
+        verify_id(id)
         get(path: "users/#{id}/districtFieldValues", params: params)
       end
 
       def create_user_district_field_values(id:, body: {})
+        verify_id(id)
         post(path: "users/#{id}/districtFieldValues", body: body)
       end
 
       def update_user_district_field_values(id:, body: {})
+        verify_id(id)
         put(path: "users/#{id}/districtFieldValues", body: body)
       end
     end

--- a/lib/ngp_van/request.rb
+++ b/lib/ngp_van/request.rb
@@ -28,7 +28,7 @@ module NgpVan
 
     def request(method:, path:, params: {}, body: {})
       response = connection.send(method) do |request|
-        request.path = URI.encode(path)
+        request.path = path
         request.params = params
         request.body = ::JSON.generate(body) unless body.empty?
       end

--- a/spec/ngp_van/client_spec.rb
+++ b/spec/ngp_van/client_spec.rb
@@ -39,6 +39,7 @@ module NgpVan
           expect(client.valid_id?(123)).to eq(true)
           expect(client.valid_id?('abc')).to eq(true)
           expect(client.valid_id?('abc-123')).to eq(true)
+          expect(client.valid_id?('onlineReferenceNumber:123')).to eq(true)
         end
       end
 

--- a/spec/ngp_van/client_spec.rb
+++ b/spec/ngp_van/client_spec.rb
@@ -30,5 +30,61 @@ module NgpVan
         expect(client.config.user_agent).to eq('test agent')
       end
     end
+
+    describe '#valid_id?' do
+      let(:client) { NgpVan::Client.new }
+
+      context 'with a valid id' do
+        it 'returns true' do
+          expect(client.valid_id?(123)).to eq(true)
+          expect(client.valid_id?('abc')).to eq(true)
+          expect(client.valid_id?('abc-123')).to eq(true)
+        end
+      end
+
+      context 'with an invalid id' do
+        it 'returns false' do
+          expect(client.valid_id?('fu?evil=mode')).to eq(false)
+          expect(client.valid_id?('fu/bar')).to eq(false)
+          expect(client.valid_id?('%20')).to eq(false)
+        end
+      end
+    end
+
+    describe '#verify_id' do
+      let(:client) { NgpVan::Client.new }
+
+      context 'with a single id' do
+        context 'when valid' do
+          it 'returns nil' do
+            expect(client.verify_id(123)).to eq(nil)
+          end
+        end
+
+        context 'when invalid' do
+          it 'raises an error' do
+            expect {
+              client.verify_id('fu?evil=mode')
+            }.to raise_error(NgpVan::InvalidID)
+          end
+        end
+      end
+
+      context 'with a list of ids' do
+        context 'when valid' do
+          it 'returns nil' do
+            expect(client.verify_id('abc', 123, 'abc-123')).to eq(nil)
+          end
+        end
+
+        context 'when invalid' do
+          it 'raises an error' do
+            expect {
+              client.verify_id('abc', 'fu?evil=mode', 'abc-123')
+            }.to raise_error(NgpVan::InvalidID)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This update adds several methods to Client instances for verifying ids are valid. Many thanks to @woodhull for pointing out the potential issue. For more on SSRF see [this article](https://www.acunetix.com/blog/articles/server-side-request-forgery-vulnerability/).