### PR TITLE
add support for delete_supporter_group

### DIFF
--- a/lib/ngp_van/client/supporter_groups.rb
+++ b/lib/ngp_van/client/supporter_groups.rb
@@ -16,6 +16,11 @@ module NgpVan
         get(path: 'supporterGroups', params: params)
       end
 
+      def delete_supporter_group(id:, params: {})
+        verify_id(id)
+        delete(path: "supporterGroups/#{id}", params: params)
+      end
+
       def add_person_to_supporter_group(supporter_group_id:, id:)
         verify_ids(id, supporter_group_id)
         put(path: "supporterGroups/#{supporter_group_id}/people/#{id}")

--- a/spec/ngp_van/client/supporter_groups_spec.rb
+++ b/spec/ngp_van/client/supporter_groups_spec.rb
@@ -66,6 +66,19 @@ module NgpVan
         end
       end
 
+      describe '#delete_supporter_group' do
+        let(:url) { build_url(client: client, path: 'supporterGroups/1122') }
+
+        before do
+          stub_request(:delete, url).to_return(status: 204, body: '')
+        end
+
+        it 'performs the request' do
+          client.delete_supporter_group(id: 1122)
+          expect(a_request(:delete, url)).to have_been_made
+        end
+      end
+
       describe '#supporter_groups' do
         let(:params) do
           {


### PR DESCRIPTION
This adds support for the `DELETE` supporter group endpoint, as documented at https://developers.everyaction.com/van-api#supporter-groups-delete-supportergroups--supportergroupid