### PR TITLE
Fix RaiseError middleware

### DIFF
--- a/lib/ngp_van/response/raise_error.rb
+++ b/lib/ngp_van/response/raise_error.rb
@@ -6,8 +6,6 @@ require 'faraday'
 module NgpVan
   module Response
     class RaiseError < Faraday::Response::Middleware
-      private
-
       def on_complete(response)
         error = NgpVan::Error.from_response(response)
         raise error if error

--- a/spec/ngp_van/request_spec.rb
+++ b/spec/ngp_van/request_spec.rb
@@ -62,6 +62,22 @@ module NgpVan
             .to have_been_made
         end
       end
+
+      context 'when the response has a non-success status code' do
+        let(:response_body) do
+          { errors: [{ code: 'NOT_FOUND', text: 'it was not found' }] }.to_json
+        end
+
+        before do
+          stub_request(:get, url).to_return(status: 404, body: response_body)
+        end
+
+        it 'raises an appropriate error' do
+          expect do
+            NgpVan.get(path: '/some/resource')
+          end.to raise_error(NgpVan::NotFound)
+        end
+      end
     end
 
     describe '#post' do


### PR DESCRIPTION
This fixes a bug that was preventing the `NgpVan::Response::RaiseError` middleware from working properly, and adds a spec for the fixed behavior.